### PR TITLE
E2e firecracker 3 ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,15 +9,15 @@ steps:
   when:
     event: [ push, pull_request ]
   commands:
-    cd aws
-    terraform validate
+    - cd aws
+    - terraform validate
 - name: validate-gcp
   image: hashicorp/terraform:0.12.20
   when:
     event: [ push, pull_request ]
   commands:
-    cd gcp
-    terraform validate
+    - cd gcp
+    - terraform validate
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,7 @@ steps:
   when:
     event: [ push, pull_request ]
     status: success
+  depends_on: [validate-aws, validate-gcp ]
   commands:
     - id="null"
     - try=1

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: docker
-name: validate
+name: test
 
 steps:
 - name: validate-aws
@@ -20,13 +20,6 @@ steps:
     - cd gcp
     - terraform init
     - terraform validate
-
----
-kind: pipeline
-type: docker
-name: trigger-e2e
-
-steps:
 - name: trigger-e2e-firecracker
   image: arwineap/docker-alpine-toolbox:latest
   environment:
@@ -35,7 +28,7 @@ steps:
   when:
     event: [ push, pull_request ]
     status: success
-  depends_on: [validate-aws, validate-gcp ]
+  depends_on: [ validate-aws, validate-gcp ]
   commands:
     - id="null"
     - try=1

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,7 @@ steps:
     event: [ push, pull_request ]
   commands:
     - cd aws
+    - terraform init
     - terraform validate
 - name: validate-gcp
   image: hashicorp/terraform:0.12.20
@@ -17,6 +18,7 @@ steps:
     event: [ push, pull_request ]
   commands:
     - cd gcp
+    - terraform init
     - terraform validate
 
 ---

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,47 @@
+---
+kind: pipeline
+type: docker
+name: validate
+
+steps:
+- name: validate-aws
+  image: hashicorp/terraform:0.12.20
+  when:
+    event: [ push, pull_request ]
+  commands:
+    cd aws
+    terraform validate
+- name: validate-gcp
+  image: hashicorp/terraform:0.12.20
+  when:
+    event: [ push, pull_request ]
+  commands:
+    cd gcp
+    terraform validate
+
+---
+kind: pipeline
+type: docker
+name: trigger-e2e
+
+- name: trigger-e2e-firecracker
+  image: arwineap/docker-alpine-toolbox:latest
+  environment:
+    E2E_TRIGGER_TOKEN:
+      from_secret: e2e_trigger_token_firecracker
+  when:
+    event: [ push, pull_request ]
+    status: success
+  commands:
+    - id="null"
+    - try=1
+    - >
+      while [ \( "$${id}" = "null" \) -a  \( $${try} -le 5 \) ]; do
+        out=$(curl -X POST -F "token=$${E2E_TRIGGER_TOKEN}" -F "ref=master" -F "variables[CI_SERVICE_BEING_TESTED]=dotscience-tf" -F "variables[CI_DOCKER_TAG]=$${DRONE_COMMIT}" -F "variables[DOTMESH_CI_BUILD_REF_NAME]=$${DRONE_COMMIT_BRANCH}" https://gitlab.dotmesh.com/api/v4/projects/dotmesh%2Fe2e-firecracker-sync/trigger/pipeline)
+        echo "RESULT: $${out}"
+        id=$(echo "$${out}" | jq .id)
+        sleep 1;
+        try=$$(( try+1 ))
+      done
+    - test "$${id}" != "null"
+    - echo "Triggered successfully, pipeline - https://gitlab.dotmesh.com/dotmesh/e2e-firecracker-sync/pipelines/$${id}"

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ kind: pipeline
 type: docker
 name: trigger-e2e
 
+steps:
 - name: trigger-e2e-firecracker
   image: arwineap/docker-alpine-toolbox:latest
   environment:


### PR DESCRIPTION
Herein is a `.drone.yml` that does some TF validation before sending the commit hash over to e2e-firecracker to trigger an E2E test run. @binocarlos is working on the code to handle that in e2e-firecracker; when it's ready, re-running the drone tests on this branch should test it - then this can be merged once Kai's work is merged in e2e-firecracker!