### PR TITLE
Network restriction

### DIFF
--- a/aws/dotscience-aws.tf
+++ b/aws/dotscience-aws.tf
@@ -316,32 +316,6 @@ resource "aws_security_group" "ds_hub_security_group" {
   }
 }
 
-resource "aws_elb" "ds_internal" {
-  name     = local.cluster_name
-  internal = true
-  listener {
-    instance_port     = 8800
-    instance_protocol = "tcp"
-    lb_port           = 8800
-    lb_protocol       = "tcp"
-  }
-
-  health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 5
-    timeout             = 5
-    target              = "HTTP:80/"
-    interval            = 30
-  }
-
-  subnets = [local.hub_subnet]
-}
-
-resource "aws_elb_attachment" "ds_internal" {
-  elb      = aws_elb.ds_internal.id
-  instance = aws_instance.ds_hub.id
-}
-
 resource "aws_eip_association" "eip_assoc" {
   instance_id   = aws_instance.ds_hub.id
   allocation_id = aws_eip.ds_eip.id
@@ -381,6 +355,7 @@ resource "aws_instance" "ds_hub" {
               set -euo pipefail
               echo "Dotscience hub"
               INSTANCE_ID=$( curl -s http://169.254.169.254/latest/meta-data/instance-id )
+              HUB_PRIVATE_IP=$( curl -s http://169.254.169.254/latest/meta-data/local-ipv4 )
               echo "Attaching volume ${aws_ebs_volume.ds_hub_volume.id} to $INSTANCE_ID"
               while ! aws ec2 attach-volume --volume-id "${aws_ebs_volume.ds_hub_volume.id}" --instance-id $INSTANCE_ID --region "${var.region}" --device /dev/sdf 
               do
@@ -392,7 +367,7 @@ resource "aws_instance" "ds_hub" {
               echo "Starting Dotscience hub"  
               sudo wget -O /usr/local/bin/ds-startup https://storage.googleapis.com/dotscience-startup/unstable/ds-startup
               sudo chmod +wx /usr/local/bin/ds-startup
-              ds-startup --admin-password "${var.admin_password}" --hub-size "${var.hub_volume_size}" --hub-device "/dev/nvme1n1" --use-kms "true" --license-key "${var.license_key}" --hub-hostname "${local.hub_hostname}" --cmk-id "${aws_kms_key.ds_kms_key.id}" --aws-region "${var.region}" --aws-sshkey "${var.key_name}" --aws-runner-sg "${aws_security_group.ds_runner_security_group.id}" --aws-subnet-id "${local.runner_subnet}" --aws-cpu-runner-image "${var.amis[var.region].CPURunner}" --aws-gpu-runner-image "${local.gpu_runner_ami}" --grafana-user "${var.grafana_admin_user}" --grafana-host "${local.grafana_host}"  --grafana-password "${var.grafana_admin_password}" --letsencrypt-mode "${var.letsencrypt_mode}" --deployer-token "${random_id.deployer_token.hex}" --deployment-ingress-class "nginx" --deployment-subdomain ".${local.deployer_model_subdomain}" --pb-runner-host "${aws_elb.ds_internal.dns_name}"
+              ds-startup --admin-password "${var.admin_password}" --hub-size "${var.hub_volume_size}" --hub-device "/dev/nvme1n1" --use-kms "true" --license-key "${var.license_key}" --hub-hostname "${local.hub_hostname}" --cmk-id "${aws_kms_key.ds_kms_key.id}" --aws-region "${var.region}" --aws-sshkey "${var.key_name}" --aws-runner-sg "${aws_security_group.ds_runner_security_group.id}" --aws-subnet-id "${local.runner_subnet}" --aws-cpu-runner-image "${var.amis[var.region].CPURunner}" --aws-gpu-runner-image "${local.gpu_runner_ami}" --grafana-user "${var.grafana_admin_user}" --grafana-host "${local.grafana_host}"  --grafana-password "${var.grafana_admin_password}" --letsencrypt-mode "${var.letsencrypt_mode}" --deployer-token "${random_id.deployer_token.hex}" --deployment-ingress-class "nginx" --deployment-subdomain ".${local.deployer_model_subdomain}" --pb-runner-host $HUB_PRIVATE_IP
               DATA_DEVICE=$(df --output=source /opt/dotscience-aws/ | tail -1)
               e2label $DATA_DEVICE data
               echo "LABEL=data      /opt/dotscience-aws      ext4   defaults,discard        0 0" >> /etc/fstab

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -33,7 +33,7 @@ variable "hub_ingress_cidr" {
 }
 
 variable "letsencrypt_ingress_cidr" {
-  description = "The CIDR block for connections coming into the Hub from https://letsencrypt.org/"
+  description = "The CIDR block for connections coming into the Hub from https://letsencrypt.org/. Let's encrypt servers do not have a whitelist IP set. Set value to '' to restrict all access."
   default     = "0.0.0.0/0"
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -167,3 +167,7 @@ variable "environment" {
   default     = "ds"
 }
 
+variable "workstation_ingress_cidr" {
+  description = "The CIDR block for connections coming into the Hub from the user's work station"
+  default = "0.0.0.0/0"
+}


### PR DESCRIPTION
Added options to restrict access to 80 (Hub). 443 (Hub), and 32607 (Dotmesh).

However - I've have had to open access to ports 9800 (tansponder), and 8800(gw) for the reason below.

As alaric put it nicely - 
> To anyone who doesn't know what we're talking about - runners and hub are on a VPC with private addresses, but runners must connect to the hub's public IP for TLS hostname checking reasons; so the connection from the runner to the hub gets routed via the NAT gateway. What's the correct spelling of an ingress rule in the hub's security group to allow this? "From the runner SG" didn't work, it seems the source SG tag on the packets is lost in the NAT translation. "From the NAT router's external IP" didn't work either, I have no theory as to why. We might try "From the runner's IP range" in case the security group is being applied to the source IP before NAT somehow (but if so, why didn't "from the runner SG" work?)...