### PR TITLE
47 fix nginx selector

### DIFF
--- a/aws/dotscience-aws.tf
+++ b/aws/dotscience-aws.tf
@@ -9,7 +9,7 @@ provider "aws" {
     session_name = "dotscience-tf"
   }
   region  = var.region
-  version = "~> 2.50.0"
+  version = "~> 2.53"
 }
 
 provider "kubernetes" {
@@ -122,7 +122,7 @@ module "ds_monitoring" {
 module "eks" {
   source                               = "terraform-aws-modules/eks/aws"
   cluster_name                         = "eks-${local.cluster_name}"
-  subnets                              = module.vpc.public_subnets
+  subnets                              = module.vpc.private_subnets
   create_eks                           = var.create_eks ? true : false
   manage_aws_auth                      = var.create_eks ? true : false
   cluster_create_timeout               = "30m"

--- a/modules/ds_deployer/main.tf
+++ b/modules/ds_deployer/main.tf
@@ -222,6 +222,7 @@ resource "helm_release" "nginx-ingress" {
 
   name       = "nginx-ingress"
   repository = data.helm_repository.stable.metadata[0].name
+  version    = "1.34.1"
   chart      = "stable/nginx-ingress"
   timeout    = 300
 
@@ -244,7 +245,6 @@ resource "kubernetes_service" "ingress_lb" {
     name = "external-ingress"
     labels = {
       "app"       = "nginx-ingress"
-      "component" = "controller"
       "release"   = "nginx-ingress"
     }
     annotations = {
@@ -254,7 +254,6 @@ resource "kubernetes_service" "ingress_lb" {
   spec {
     selector = {
       "app"       = "nginx-ingress"
-      "component" = "controller"
       "release"   = "nginx-ingress"
     }
 


### PR DESCRIPTION
closes #47 

 * fix the version selector for the aws provider
 * use private subnets for EKS
 * pin the version of the nginx-ingress helm chart
 * don't use a controller selector for nginx-ingress service