### PR TITLE
FIX: standardise output names between aws and gcp

### DIFF
--- a/aws/dotscience-aws.tf
+++ b/aws/dotscience-aws.tf
@@ -40,6 +40,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   hub_hostname             = join("", [replace(aws_eip.ds_eip.public_ip, ".", "-"), ".", var.dotscience_domain])
+  hub_ip                   = aws_eip.ds_eip.public_ip
   hub_subnet               = module.vpc.public_subnets[0]
   runner_subnet            = module.vpc.private_subnets[0]
   deployer_token           = random_id.deployer_token.hex

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,15 +1,19 @@
-output "DotscienceHub_IP" {
-  value = "http://${aws_eip.ds_eip.public_ip}"
+output "hub_public_url" {
+  value = join("", ["https://", local.hub_hostname])
 }
 
-output "DotscienceHub_URL" {
-  value = "https://${local.hub_hostname}"
+output "hub_public_ip" {
+  value = local.hub_ip
 }
 
-output "Grafana_URL" {
+output "grafana_host" {
   value = local.grafana_host
 }
 
-output "CLI_env_file" {
+output "models_served_under" {
+  value = local.deployer_model_subdomain
+}
+
+output "cli_env_file" {
   value = "source .ds_env.sh"
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -1,4 +1,3 @@
-
 output "hub_public_url" {
   value = join("", ["https://", local.hub_hostname])
 }
@@ -23,6 +22,6 @@ output "gke_cluster_name" {
   value = "dotscience-deployer-${random_id.default.hex}"
 }
 
-output "CLI_env_file" {
+output "cli_env_file" {
   value = "source .ds_env.sh"
 }


### PR DESCRIPTION
Make the output key names the same between aws and GCP