### PR TITLE
Private models

### DIFF
--- a/aws/dotscience-aws.tf
+++ b/aws/dotscience-aws.tf
@@ -465,12 +465,10 @@ resource "aws_eip" "ds_model_eip" {
 resource "aws_lb" "ds_model_nlb" {
   count = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-ga" ? 1 : 0
   
-  # A second NLB to point to the first one created by Kubernetes, to compensate
-  # for the fact that K8s 1.15 clusters can't associate NLBs with EIPs (and we
-  # need an EIP so that we can use the *.models.1-2-3-4.your.dots.ci trick).
-  # Then we can set load_balancer_source_ranges on the k8s NLB and because IP
-  # source info is preserved thru an NLB (but not a GA) we'll be able to restrict
-  # models to be private (at least restrict them to an internal CIDR).
+  # An NLB to associate with an EIP, pointing to nginx on NodePort on the
+  # workers in Kubernetes. We can't express this directly in Kubernetes because
+  # K8s 1.15 clusters can't associate NLBs with EIPs (and we need an EIP so that
+  # we can use the *.models.1-2-3-4.your.dots.ci trick).
 
   load_balancer_type = "network"
 

--- a/aws/dotscience-aws.tf
+++ b/aws/dotscience-aws.tf
@@ -491,6 +491,8 @@ resource "aws_lb_listener" "ds_model_front_end" {
 }
 
 resource "aws_lb_target_group" "ds_model_front_end_tg" {
+  count = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-eip" ? 1 : 0
+
   target_type = "instance"
   port     = 30080
   protocol = "TCP"

--- a/aws/dotscience-aws.tf
+++ b/aws/dotscience-aws.tf
@@ -486,7 +486,7 @@ resource "aws_lb_listener" "ds_model_front_end" {
   protocol          = "TCP"
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.ds_model_front_end_tg.arn
+    target_group_arn = aws_lb_target_group.ds_model_front_end_tg[0].arn
   }
 }
 
@@ -506,5 +506,5 @@ resource "aws_lb_target_group" "ds_model_front_end_tg" {
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
   count = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-eip" ? 1 : 0
   autoscaling_group_name = module.eks.workers_asg_names[0]
-  alb_target_group_arn   = aws_lb_target_group.ds_model_front_end_tg.arn
+  alb_target_group_arn   = aws_lb_target_group.ds_model_front_end_tg[0].arn
 }

--- a/aws/dotscience-aws.tf
+++ b/aws/dotscience-aws.tf
@@ -51,9 +51,7 @@ locals {
   cpu_runner_ami           = var.amis[var.region].CPURunner
   gpu_runner_ami           = var.amis[var.region].GPURunner
   nat_cidrs                = [for ip in module.vpc.nat_public_ips : "${ip}/32"]
-  ingress_elb_arn_type     = var.create_deployer && var.create_eks ? split("-", local.ingress_elb_name)[0] : ""
-  ingress_elb_arn_id       = var.create_deployer && var.create_eks ? split(".", (split("-", local.ingress_elb_name)[1]))[0] : ""
-  deployer_model_subdomain = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-ga" ? join("", ["model-", replace(aws_globalaccelerator_accelerator.ds_model_ingress[0].ip_sets[0].ip_addresses[0], ".", "-"), ".", var.dotscience_domain]) : "model-${local.cluster_name}.${var.model_deployment_domain}"
+  deployer_model_subdomain = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-ga" ? join("", ["model-", replace(aws_eip.ds_model_eip[0].public_ip, ".", "-"), ".", var.dotscience_domain]) : "model-${local.cluster_name}.${var.model_deployment_domain}"
 }
 
 data "aws_eks_cluster" "cluster" {
@@ -120,6 +118,22 @@ module "ds_monitoring" {
   dotscience_environment = "aws"
 }
 
+
+resource "aws_security_group" "eks_additional_ingress_security_group" {
+  name        = "eks-additional-ingress-sg-${random_id.default.hex}"
+  description = "SG for EKS workers"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 30080
+    to_port     = 30080
+    protocol    = "tcp"
+    cidr_blocks = var.model_ingress_cidrs
+    description = "access model ingress"
+  }
+}
+
+
 module "eks" {
   source                               = "terraform-aws-modules/eks/aws"
   cluster_name                         = "eks-${local.cluster_name}"
@@ -131,6 +145,7 @@ module "eks" {
   cluster_endpoint_private_access      = true
   cluster_endpoint_public_access       = true
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
+  worker_additional_security_group_ids = [aws_security_group.eks_additional_ingress_security_group.id]
 
   tags = {
     Environment = local.cluster_name
@@ -460,7 +475,7 @@ resource "aws_lb" "ds_model_nlb" {
   load_balancer_type = "network"
 
   subnet_mapping {
-    subnet_id     = module.vpc.public_subnets[1] # XXX point to all subnets? but one EIP per subnet...
+    subnet_id     = module.vpc.public_subnets[0]
     allocation_id = aws_eip.ds_model_eip[0].id
   }
 }
@@ -473,57 +488,22 @@ resource "aws_lb_listener" "ds_model_front_end" {
   protocol          = "TCP"
   default_action {
     type             = "forward"
-    # target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:108998689641:targetgroup/k8s-default-external-1a4b08fbd6/66d0528088f0914c" <- didn't work trying to reuse existing target group as you can only attach a target group to one LB at a time
-    target_group_arn = "${aws_lb_target_group.ds_model_front_end_tg.arn}"
+    target_group_arn = aws_lb_target_group.ds_model_front_end_tg.arn
   }
 }
-
-# Target all the workers in e.g. eks-luke-testing-9b710711-worker-group-1-eks_asg on port 31097
-# Question - will this port ever change?
 
 resource "aws_lb_target_group" "ds_model_front_end_tg" {
   target_type = "instance"
-  port     = 31097
+  port     = 30080
   protocol = "TCP"
   vpc_id   = module.vpc.vpc_id
-}
 
-resource "aws_lb_target_group_attachment" "ds_model_front_end_tg_attachment" {
-  target_group_arn = "${aws_lb_target_group.ds_model_front_end_tg.arn}"
-  target_id        = "i-00fa4f825f4a0815b"
-  port             = 31097
-}
-
-# EKS creates a target group for an ingress named like: k8s-default-external-27908e6273
-# How can we get its ARN?
-
-resource "aws_globalaccelerator_accelerator" "ds_model_ingress" {
-  name            = "Model"
-  ip_address_type = "IPV4"
-  enabled         = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-ga" ? true : false
-  count           = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-ga" ? 1 : 0
-}
-
-resource "aws_globalaccelerator_endpoint_group" "ds_model_ingress" {
-  listener_arn = aws_globalaccelerator_listener.ds_model_ingress[0].id
-  endpoint_configuration {
-    endpoint_id = join("", concat(["arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/net/"], [local.ingress_elb_arn_type, "/", local.ingress_elb_arn_id]))
-    weight      = 100
+  lifecycle {
+    create_before_destroy = true
   }
-  health_check_path             = "/"
-  health_check_port             = 80
-  health_check_interval_seconds = 30
-  count                         = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-ga" ? 1 : 0
 }
 
-resource "aws_globalaccelerator_listener" "ds_model_ingress" {
-  accelerator_arn = aws_globalaccelerator_accelerator.ds_model_ingress[0].id
-  client_affinity = "SOURCE_IP"
-  protocol        = "TCP"
-  count           = var.create_deployer && var.create_eks && var.model_deployment_mode == "aws-ga" ? 1 : 0
-
-  port_range {
-    from_port = 80
-    to_port   = 80
-  }
+resource "aws_autoscaling_attachment" "asg_attachment_bar" {
+  autoscaling_group_name = module.eks.workers_asg_names[0]
+  alb_target_group_arn   = aws_lb_target_group.ds_model_front_end_tg.arn
 }

--- a/aws/inputs.tfvars.template
+++ b/aws/inputs.tfvars.template
@@ -13,3 +13,6 @@ environment             = "ds-prod"
 region                  = "eu-west-2"
 dns_management          = "self"
 model_deployment_domain = "dotscience-deploy.net"
+hub_ingress_cidrs      = ["0.0.0.0/0"]
+ssh_access_cidrs       = ["0.0.0.0/0"]
+model_ingress_cidrs    = ["0.0.0.0/0"]

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -14,6 +14,10 @@ output "models_served_under" {
   value = local.deployer_model_subdomain
 }
 
+output "model_eip" {
+  value = aws_eip.ds_model_eip[0].public_ip
+}
+
 output "cli_env_file" {
   value = "source .ds_env.sh"
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -14,10 +14,6 @@ output "models_served_under" {
   value = local.deployer_model_subdomain
 }
 
-output "model_eip" {
-  value = aws_eip.ds_model_eip[0].public_ip
-}
-
 output "cli_env_file" {
   value = "source .ds_env.sh"
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -168,11 +168,11 @@ variable "environment" {
 }
 
 variable "model_deployment_mode" {
-  description = "Set to 'aws-ga' to host models on model-abc.1-2-3-4.your.dots.ci or 'route53' to host models on model-abc.your.domain.com"
-  default     = "aws-ga"
+  description = "Set to 'aws-eip' to host models on model-abc.1-2-3-4.your.dots.ci or 'route53' to host models on model-abc.your.domain.com"
+  default     = "aws-eip"
 
   validation {
-    condition     = var.model_deployment_mode == "aws-ga" || var.model_deployment_mode == "route53"
-    error_message = "Set to 'aws-ga' to host models on model-abc.1-2-3-4.your.dots.ci or 'route53' to host models on model-abc.your.domain.com."
+    condition     = var.model_deployment_mode == "aws-eip" || var.model_deployment_mode == "route53"
+    error_message = "Set to 'aws-eip' to host models on model-abc.1-2-3-4.your.dots.ci or 'route53' to host models on model-abc.your.domain.com."
   }
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -32,6 +32,11 @@ variable "hub_ingress_cidrs" {
   description = "The CIDR block for connections coming into the Hub"
 }
 
+variable "model_ingress_cidrs" {
+  description = "The CIDR block for allowed connections to hosted models"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "letsencrypt_ingress_cidr" {
   description = "The CIDR block for connections coming into the Hub from https://letsencrypt.org/. Let's encrypt servers do not have a whitelist IP set. Set value to '' to restrict all access."
   default     = "0.0.0.0/0"

--- a/modules/ds_deployer/main.tf
+++ b/modules/ds_deployer/main.tf
@@ -254,9 +254,6 @@ resource "kubernetes_service" "ingress_lb" {
       "app.kubernetes.io/component" = "controller"
       "release"                     = "nginx-ingress"
     }
-    annotations = {
-      "service.beta.kubernetes.io/aws-load-balancer-type" = "nlb"
-    }
   }
   spec {
     selector = {
@@ -267,15 +264,16 @@ resource "kubernetes_service" "ingress_lb" {
 
     port {
       name        = "app"
-      port        = 80
+      port        = 30080
+      node_port   = 30080
       target_port = "http"
       protocol    = "TCP"
     }
 
-    type = "LoadBalancer"
+    type = "NodePort"
   }
 }
 
 locals {
-  ingress_host = var.dotscience_environment == "aws" ? kubernetes_service.ingress_lb[*].load_balancer_ingress[0].hostname : kubernetes_service.ingress_lb[*].load_balancer_ingress[0].ip
+  ingress_host = var.dotscience_environment == "aws" ? ["<NodePort on 30080>"] : kubernetes_service.ingress_lb[*].load_balancer_ingress[0].ip
 }


### PR DESCRIPTION
- New toggle: `model_ingress_cidrs` a list of CIDRs to allow access to models (implemented in additional EKS security group for workers)
- Remove Global Accelerator
- Remove LoadBalancer for k8s nginx ingress, replace with NodePort
- Created new EIP
- Created new NLB with EIP association
- Automated joining of autoscaling group to target group for NLB